### PR TITLE
Rename lineage.dependencies to crdroid.dependencies and update

### DIFF
--- a/crdroid.dependencies
+++ b/crdroid.dependencies
@@ -1,0 +1,8 @@
+[
+  {
+    "repository"  : "crdroidandroid/android_kernel_oneplus_sdm845",
+    "target_path" : "kernel/oneplus/sdm845",
+    "revision"    : "10.0",
+    "remote"      : "github"
+  }
+]

--- a/lineage.dependencies
+++ b/lineage.dependencies
@@ -1,6 +1,0 @@
-[
-  {
-    "repository": "android_kernel_oneplus_sdm845",
-    "target_path": "kernel/oneplus/sdm845"
-  }
-]


### PR DESCRIPTION
Rename file to be automatically picked up & referenced by build system, and fix repository path & add rest of manifest information so that roomservice will successfully pull in kernel sources without manual edits to local_manifests.